### PR TITLE
Fix NPE crash on freshly created worlds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ plugins {
     id 'net.darkhax.curseforgegradle' version '1.0.11'
 }
 
-def fileVersion = "1.1.1"
+def fileVersion = "1.1.2"
 
 version = "1.7.10-$fileVersion"
 

--- a/src/main/java/net/jomcraft/frustrator/network/C2SNewAreaPacket.java
+++ b/src/main/java/net/jomcraft/frustrator/network/C2SNewAreaPacket.java
@@ -87,6 +87,12 @@ public class C2SNewAreaPacket implements IMessage {
             final int maxY = Math.max((int) message.pos1.yCoord, (int) message.pos2.yCoord);
             final int maxZ = Math.max((int) message.pos1.zCoord, (int) message.pos2.zCoord);
 
+            if(!FileManager.getFrustumJSON().getChannelMap().containsKey(player.dimension)) {
+                HashMap<Integer, String> newMap = new HashMap<Integer, String>();
+                newMap.put(0, "Default");
+                FileManager.getFrustumJSON().getChannelMap().put(player.dimension, newMap);
+            }
+            
             if (!FileManager.getFrustumJSON().getChannelMap().get(player.dimension).containsKey(message.channelID)) {
                 player.addChatMessage(new ChatComponentTranslation("frustrator.create.fail.channel", new Object[]{(message.parent == null ? "main" : "trigger")}).setChatStyle(ClientEventHandler.style.setColor(EnumChatFormatting.YELLOW)));
                 return null;


### PR DESCRIPTION
Fixing major oversight in the packet management system for creating new areas. Thanks to @AlexSocol for reporting!